### PR TITLE
feat: make responding service calls generic

### DIFF
--- a/src/build.extension.ts
+++ b/src/build.extension.ts
@@ -59,6 +59,7 @@ export function BuildTypes({ logger, hass, type_build, config, internal }: TServ
         `  AppleNotificationData,`,
         `  NotificationData,`,
         `  PICK_ENTITY,`,
+        `  WeatherGetForecasts,`,
         `} from "./helpers";`,
         ``,
         PICK_FROM_PLATFORM,

--- a/src/i-call-service.extension.ts
+++ b/src/i-call-service.extension.ts
@@ -1,6 +1,6 @@
 import { DOWN, is, TServiceParams, UP } from "@digital-alchemy/core";
 import { HassServiceDTO, ServiceListField, ServiceListServiceTarget } from "@digital-alchemy/hass";
-import { factory, SyntaxKind, TypeElement } from "typescript";
+import { factory, SyntaxKind, TypeElement, TypeNode } from "typescript";
 
 export async function ICallServiceExtension({ hass, type_build }: TServiceParams) {
   return async function () {
@@ -50,6 +50,13 @@ export async function ICallServiceExtension({ hass, type_build }: TServiceParams
       // >   }
       // > }
       const genericIdent = "T";
+      let defaultReturnType: TypeNode = factory.createKeywordTypeNode(SyntaxKind.VoidKeyword);
+      if (domain === "weather" && key === "get_forecasts") {
+        defaultReturnType = factory.createTypeReferenceNode(
+          factory.createIdentifier("WeatherGetForecasts"),
+          undefined,
+        );
+      }
       return type_build.tsdoc.serviceComment(
         factory.createMethodSignature(
           undefined,
@@ -60,7 +67,7 @@ export async function ICallServiceExtension({ hass, type_build }: TServiceParams
               undefined,
               factory.createIdentifier(genericIdent),
               undefined,
-              factory.createKeywordTypeNode(SyntaxKind.VoidKeyword),
+              defaultReturnType,
             ),
           ],
           serviceParameters(domain, key, value),

--- a/src/i-call-service.extension.ts
+++ b/src/i-call-service.extension.ts
@@ -49,15 +49,23 @@ export async function ICallServiceExtension({ hass, type_build }: TServiceParams
       // >     [service_name]: (service_data) => Promise<void | unknown>
       // >   }
       // > }
+      const genericIdent = "T";
       return type_build.tsdoc.serviceComment(
         factory.createMethodSignature(
           undefined,
           factory.createIdentifier(key),
           undefined,
-          undefined,
+          [
+            factory.createTypeParameterDeclaration(
+              undefined,
+              factory.createIdentifier(genericIdent),
+              undefined,
+              factory.createKeywordTypeNode(SyntaxKind.VoidKeyword),
+            ),
+          ],
           serviceParameters(domain, key, value),
-          factory.createTypeReferenceNode(factory.createIdentifier("Promise"), [
-            factory.createKeywordTypeNode(SyntaxKind.VoidKeyword),
+          factory.createExpressionWithTypeArguments(factory.createIdentifier("Promise"), [
+            factory.createTypeReferenceNode(factory.createIdentifier(genericIdent), undefined),
           ]),
         ),
         key,


### PR DESCRIPTION
## 📬 Changes

Makes responding service calls generic, with option to override in known cases like `weather.get_forecasts`

Goes along with https://github.com/Digital-Alchemy-TS/hass/pull/65

Fixes #10 

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed) - Tested Manually
