### PR TITLE
Fix TypeError when entity unique_id is numeric

### DIFF
--- a/src/identifiers.service.mts
+++ b/src/identifiers.service.mts
@@ -213,7 +213,7 @@ export function Identifiers({ hass, logger }: TServiceParams) {
         list.map(entity =>
           factory.createPropertySignature(
             undefined,
-            factory.createStringLiteral(entity.unique_id),
+            factory.createStringLiteral(String(entity.unique_id)),
             undefined,
             factory.createLiteralTypeNode(factory.createStringLiteral(entity.entity_id)),
           ),


### PR DESCRIPTION
## Problem
The type-writer crashes with `TypeError: s.replace is not a function` when Home Assistant entities have numeric `unique_id` values instead of strings.

## Root Cause
Some Home Assistant entities return numeric unique IDs (e.g., `5545915`, `350373349`) but the code assumed all unique IDs were strings, causing `createStringLiteral()` to fail.

## Solution
Convert `entity.unique_id` to string before passing to `createStringLiteral()`. This preserves semantic meaning while ensuring compatibility since TypeScript object property names are always strings anyway.

## Testing
- ✅ Build passes
- ✅ Linting passes  
- ✅ Verified fix resolves the TypeError in real Home Assistant environments

Fixes the edge case where type generation fails on entities with numeric unique identifiers.