### PR TITLE
Coerce sensor options to string

### DIFF
--- a/src/ast-fragments.service.mts
+++ b/src/ast-fragments.service.mts
@@ -126,7 +126,9 @@ export function ASTFragmentsExtension({ type_build }: TServiceParams) {
     );
   const union = (list: string[]) =>
     factory.createUnionTypeNode(
-      list.map(option => factory.createLiteralTypeNode(factory.createStringLiteral(option))),
+      list.map(option =>
+        factory.createLiteralTypeNode(factory.createStringLiteral(String(option))),
+      ),
     );
 
   return {


### PR DESCRIPTION
## 📬 Changes

- Sometimes `options` comes in with null and makes things mad, this forces it to always be string
```json
"options": [
  null,
  "Routing",
  "Routing IP Secure",
  "Tunnel IP Secure",
  "Tunnel TCP",
  "Tunnel UDP"
],
```

> `null` -> `"null"`

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
